### PR TITLE
fix:  github redirection for github actions related packages

### DIFF
--- a/src/components/malysis/MalwareAnalysisReportCard.tsx
+++ b/src/components/malysis/MalwareAnalysisReportCard.tsx
@@ -81,7 +81,7 @@ export default function MalwareAnalysisReportCard({
         })}
       >
         <CardHeader>
-            <div className="flex items-center justify-between flex-wrap">
+          <div className="flex items-center justify-between flex-wrap">
             <h1 className="text-2xl font-mono group break-all">
               <Link
                 href={packageUrl}

--- a/src/components/malysis/MalwareAnalysisReportCard.tsx
+++ b/src/components/malysis/MalwareAnalysisReportCard.tsx
@@ -81,8 +81,8 @@ export default function MalwareAnalysisReportCard({
         })}
       >
         <CardHeader>
-          <div className="flex items-center justify-between">
-            <h1 className="text-2xl font-mono group">
+            <div className="flex items-center justify-between flex-wrap">
+            <h1 className="text-2xl font-mono group break-all">
               <Link
                 href={packageUrl}
                 target="_blank"

--- a/src/lib/rpc/utils.test.ts
+++ b/src/lib/rpc/utils.test.ts
@@ -74,9 +74,7 @@ describe("packageRegistryUrl", () => {
     const p = create(PackageVersionSchema, {
       package: { ecosystem: Ecosystem.GITHUB_ACTIONS, name: "foo" },
     });
-    expect(packageRegistryUrl(p)).toBe(
-      "https://github.com/marketplace/actions/foo",
-    );
+    expect(packageRegistryUrl(p)).toBe("https://github.com/foo");
   });
 
   it("returns the correct URL for PACKAGIST packages", () => {

--- a/src/lib/rpc/utils.ts
+++ b/src/lib/rpc/utils.ts
@@ -23,7 +23,7 @@ export function packageRegistryUrl(p?: PackageVersion): string {
     case Ecosystem.GO:
       return `https://pkg.go.dev/${name}`;
     case Ecosystem.GITHUB_ACTIONS:
-      return `https://github.com/marketplace/actions/${name}`;
+      return `https://github.com/${name}`;
     case Ecosystem.PACKAGIST:
       return `https://packagist.org/packages/${name}`;
     case Ecosystem.TERRAFORM:


### PR DESCRIPTION
closes: #124 

1. The package name which is being provided is actually for github action's repositories not github action marketplace.
2. fixed some minor css fixes