### PR TITLE
fix: refresh token on expiry

### DIFF
--- a/src/lib/session/session.ts
+++ b/src/lib/session/session.ts
@@ -39,7 +39,7 @@ export async function getTenantAndToken() {
   }
 
   try {
-    const accessToken = (await auth0.getSession())?.tokenSet.accessToken;
+    const accessToken = (await auth0.getAccessToken()).token;
     if (!accessToken) {
       return redirect("/auth");
     }

--- a/src/middleware.ts
+++ b/src/middleware.ts
@@ -5,9 +5,13 @@ export async function middleware(request: NextRequest) {
   // 1) Mounts the /api/auth/* handlers, parses cookies, etc.
   const response = await auth0.middleware(request);
 
-  // 2) If there’s a refresh-token available and the access-token is expired,
+  // 2) If there's a refresh-token available and the access-token is expired,
   //    this will grab a fresh AT and persist new cookies on `response`.
-  await auth0.getAccessToken(request, response);
+  const session = await auth0.getSession(request);
+  if (session) {
+    // only runs when user is logged in
+    await auth0.getAccessToken(request, response);
+  }
 
   return response;
 }

--- a/src/middleware.ts
+++ b/src/middleware.ts
@@ -2,7 +2,14 @@ import type { NextRequest } from "next/server";
 import { auth0 } from "./lib/auth0";
 
 export async function middleware(request: NextRequest) {
-  return await auth0.middleware(request);
+  // 1) Mounts the /api/auth/* handlers, parses cookies, etc.
+  const response = await auth0.middleware(request);
+
+  // 2) If there’s a refresh-token available and the access-token is expired,
+  //    this will grab a fresh AT and persist new cookies on `response`.
+  await auth0.getAccessToken(request, response);
+
+  return response;
 }
 
 export const config = {


### PR DESCRIPTION
- **fix: use `getAccessToken` to refresh token automatically**
- **feat: perform auto refresh and persistence of cookies in middleware**

https://auth0.github.io/nextjs-auth0/classes/server.Auth0Client.html#getaccesstoken
