### PR TITLE
fix: show safedep logo if file evidences exist

### DIFF
--- a/src/app/community/packages/[ecosystem]/[...nameAndVersion]/_components/tabs/analysis-tab.tsx
+++ b/src/app/community/packages/[ecosystem]/[...nameAndVersion]/_components/tabs/analysis-tab.tsx
@@ -80,7 +80,7 @@ export default async function AnalysisTab({
                 </time>
               </span>
             ) : (
-              <span />
+              <div />
             )}
 
             {(report.fileEvidences.length > 0 || report.reportId) && (


### PR DESCRIPTION
closes #202
